### PR TITLE
Ensure the blacklist lookup uses a fully qualified domain name

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -77,7 +77,7 @@ function ozh_yourls_antispam_is_blacklisted( $url ) {
 	
 	// Check against each blacklist, exit if blacklisted
 	foreach( $blacklists as $blacklist ) {
-		$domain = $parsed['host'] . '.' . $blacklist;
+		$domain = $parsed['host'] . '.' . $blacklist . '.';
 		$record = dns_get_record( $domain );
 		
 		if( count( $record ) > 0 )


### PR DESCRIPTION
Without the trailing '.' the lookup might have a local domain appended
per /etc/resolv.conf on a poxsix system, for example.  This can cause
spurious failures.

I ran into this in an environment where we have a wildcard MX record
in place.  The result was that dns_get_record() returned a result for
<host>.<blacklist>.<our-domain> and subsequently treated every URL as
blacklisted. ;)
