### PR TITLE
Bugfix: confusion about spamhaus' ZEN vs. DBL

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -76,7 +76,7 @@ function ozh_yourls_antispam_is_blacklisted( $url ) {
 	// Major blacklists. There's a filter if you want to manipulate this.
 	$blacklists = yourls_apply_filter( 'ozh_yourls_antispam_list',
 		array(
-			'zen.spamhaus.org',
+			'dbl.spamhaus.org',
 			'multi.surbl.org',
 			'black.uribl.com',
 		)


### PR DESCRIPTION
Quoting http://www.spamhaus.org/zen/: "ZEN is the combination of all Spamhaus IP-based DNSBLs into one single powerful and comprehensive blocklist to make querying faster and simpler. It contains the SBL, SBLCSS, XBL and PBL blocklists."

These are all IP-based block (or black) lists, i.e. they do not cover domain names. Your code however tests whether a hostname is blacklisted. Spamhaus has a separate list for this purpose, called the DBL. This is the list you should use here. For instance, on a Unix machine

host dbltest.com.zen.spamhaus.org 

will report a non-existent domain, while 

host dbltest.com.dbl.spamhaus.org

will result in the address 127.0.1.2, indicating a spam domain (in this case, this is just a permanent test point for the list). You can also use the unix 'dig' command instead of 'host', or 'nslookup' in a shell under MS Windows(tm).

A perhaps more convincing example with a real spam domain (BE AWARE, DON'T VISIT IT):

host controlins.com.zen.spamhaus.org 

will yield a non-existing domain, while 

host controlins.com.dbl.spamhaus.org

yields 127.0.1.2 (thus detecting the spam domain). You can also try shortening 'http://controlins.com-MUNGED' (without the '-MUNGED' part) in a YOURLS shortener, where the current version of the antispam plugin is activated. Since, unfortunately, neither SURBL nor URIBL, ATTOW, know the aforementioned spam domain, it will pass the check, and a short URL is created, duh. With the bug fix applied however (zen -> dbl), this filthy URI is rejected. 

(Again, this hold ATTOW, as you know things can change quickly, as the lists are being updated continuously).