### PR TITLE
Make ozh_yourls_antispam_check_add cooperate

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -17,7 +17,7 @@ function ozh_yourls_antispam_check_add( $false, $url ) {
 
     // only check for 'http(s)'
     if( !in_array( yourls_get_protocol( $url ), array( 'http://', 'https://' ) ) )
-        return false;
+        return $false;
 
 	if ( ozh_yourls_antispam_is_blacklisted( $url ) != false ) {
 		return array(
@@ -29,7 +29,7 @@ function ozh_yourls_antispam_check_add( $false, $url ) {
 	}
 	
 	// All clear, not interrupting the normal flow of events
-	return false;
+	return $false;
 }
 
 


### PR DESCRIPTION
This PR makes `ozh_yourls_antispam_check_add` cooperate better with other filters:

Problem: 

Let us assume that a third-party filter uses the same hook `shunt_add_new_link` as `ozh_yourls_antispam_check_add`, and is being called before `ozh_yourls_antispam_check_add` in the filter chain (e.g. due to the alphabetical order of the function callbacks). Let us further assume that this third-party filter returns a flag $false with a value different from `false`.

Then the current behavior [behaviour] of filter `ozh_yourls_antispam_check_add` is such that `$false` is not passed on in the chain, but instead being replaced by the value `false`, if the antispam check itself did not find a problem. Because of that, third-party filters then cannot interrupt the normal flow of events in case they find (and e.g. want to make YOURLS to report) a problem.

This problem is also related to the (closed) issue [#1688](https://github.com/YOURLS/YOURLS/issues/1688) (its respective discussion including an explanation of the filter chain by @ozh):

Here, **o**`zh_yourls_antispam_check_add` was served after  **c**`hurl_reachability` because of 'o' >_lex 'c', thereby replacing anything which is returned/passed on in the filter chain by `churl_reachability`, by `false` (subsequently, the issue had been resolved by the author @adigitalife, namely by giving `churl_reachability` a priority of 1).

And on a side note,  `ozh_yourls_`**g**`sb_check_add` (in the google-safe-browsing plugin) is served after `ozh_yourls_`**a**`ntispam_check` ('g' >_lex 'a'), so the flag returned by `ozh_yourls_gsb_check_add` seems to just 'luckily survive' in the filter chain.

Fix: return passed parameter `$false` instead of `false` in two places in `ozh_yourls_antispam_check_add`.