### PR TITLE
Proper distinction between failure reasons

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -19,14 +19,23 @@ function ozh_yourls_antispam_check_add( $false, $url ) {
     if( !in_array( yourls_get_protocol( $url ), array( 'http://', 'https://' ) ) )
         return $false;
 
-	if ( ozh_yourls_antispam_is_blacklisted( $url ) != false ) {
+    if ( ozh_yourls_antispam_is_blacklisted( $url ) === yourls_apply_filter( 'ozh_yourls_antispam_malformed', 'malformed' ) ) {
+		return array(
+			'status' => 'fail',
+			'code'   => 'error:nourl',
+			'message' => yourls__( 'Missing or malformed URL' ),
+			'errorCode' => '400',
+		);
+    }
+	
+    if ( ozh_yourls_antispam_is_blacklisted( $url ) != false ) {
 		return array(
 			'status' => 'fail',
 			'code'   => 'error:spam',
 			'message' => 'This domain is blacklisted',
 			'errorCode' => '403',
 		);
-	}
+    }
 	
 	// All clear, not interrupting the normal flow of events
 	return $false;


### PR DESCRIPTION
This PR fixes a minor flaw in `ozh_yourls_antispam_check_add` in the antispam plugin:

Said function does not distinguish between the two failure reasons a) blacklisted and b) malformed URL.

To make the flaw evident, e.g. on a fresh install with nothing but the antispam plugin activated, try shortening **http:///google.com** via the admin panel (notice that the URL has three slashes in a row!). Oddly, the user is notified 'This domain is blacklisted' instead of the correct notification 'Missing or malformed URL'.

Fix: Inserted the respective check for malformedness (which is already prepared in `ozh_yourls_antispam_is_blacklisted`) and returned the appropriate result array for this case.